### PR TITLE
Rename composer package #2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "soderlind/wxr2psd",
+    "name": "soderlind/wxr2pdf",
     "description": "Convert an WordPress Export to PDF",
     "version": "0.0.3",
     "type": "wordpress-plugin",


### PR DESCRIPTION
Fixing #2.

Renaming the composer package to make the path consistent independently of how you install it.